### PR TITLE
Update RconPacket.java

### DIFF
--- a/src/main/java/org/glavo/rcon/RconPacket.java
+++ b/src/main/java/org/glavo/rcon/RconPacket.java
@@ -147,7 +147,7 @@ final class RconPacket {
             dis.read(new byte[2]);
 
             return new RconPacket(requestId, type, payload);
-        } catch (BufferUnderflowException | EOFException e) {
+        } catch (BufferUnderflowException | EOFException | NegativeArraySizeException e) {
             throw new MalformedPacketException("Cannot read the whole packet");
         }
     }


### PR DESCRIPTION
When using this library, it failed to initialize with following expections:

> java.lang.NegativeArraySizeException: -10
>        at org.glavo.rcon.RconPacket.read(RconPacket.java:138) ~[rcon-java-3.0.jar!/:na]
>        at org.glavo.rcon.RconPacket.send(RconPacket.java:82) ~[rcon-java-3.0.jar!/:na]
>        at org.glavo.rcon.Rcon.send(Rcon.java:173) ~[rcon-java-3.0.jar!/:na]
>        at org.glavo.rcon.Rcon.connect(Rcon.java:108) ~[rcon-java-3.0.jar!/:na]
>        at org.glavo.rcon.Rcon.connect(Rcon.java:124) ~[rcon-java-3.0.jar!/:na]
>        at org.glavo.rcon.Rcon.<init>(Rcon.java:80) ~[rcon-java-3.0.jar!/:na]
>        at org.glavo.rcon.Rcon.<init>(Rcon.java:68) ~[rcon-java-3.0.jar!/:na]

In my code, I captured both IOException and AuthenticationException, but not NegativeArraySizeException since it is not declared in Rcon() constructor. However, when the server I'm monitoring whent accidentally down, the Rcon() constructor throws NegativeArraySizeException instead of IOException. After some digging in code, I found you may have forgotten the possibility of empty response from the server?( I'm not familiar with internet communocation protocols, I may not be right about this)
